### PR TITLE
Fix _get_message returning the message cache.

### DIFF
--- a/discord/state.py
+++ b/discord/state.py
@@ -256,7 +256,7 @@ class ConnectionState:
             self._private_channels_by_user.pop(channel.recipient.id, None)
 
     def _get_message(self, msg_id):
-        return self._messages and utils.find(lambda m: m.id == msg_id, reversed(self._messages))
+        return utils.find(lambda m: m.id == msg_id, reversed(self._messages)) if self._messages else None
 
     def _add_guild_from_data(self, guild):
         guild = Guild(data=guild, state=self)


### PR DESCRIPTION
### Summary

This pull request fixes ``ConnectionState._get_message`` returning the message cache instead of a single message (or ``None``).
This happens when ``_get_message`` is called with an empty cache.

### Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
